### PR TITLE
POC main vs release

### DIFF
--- a/.github/workflows/test-chia-main.yml
+++ b/.github/workflows/test-chia-main.yml
@@ -1,5 +1,5 @@
 ---
-name: Run Test Suite
+name: Test chia-blockchain main
 
 on:
   workflow_dispatch:
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    name: All tests
+    name: All tests @main
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -45,7 +45,7 @@ jobs:
         run: |
           python3 -m venv venv
           . ./venv/bin/activate
-          pip install --extra-index https://pypi.chia.net/simple/ --editable .[release]
+          pip install --extra-index https://pypi.chia.net/simple/ --editable .[dev]
           chia init
           echo -ne "\n" | cdv sim create
           export CHIA_ROOT=~/.chia/simulator/main/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 ; logging options
 log_cli = False
-addopts = --verbose --tb=short -n auto -p no:monitor
+addopts = --verbose --tb=short -p no:monitor
 log_level = WARNING
 console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,20 @@ with open("README.md", "rt", encoding="UTF-8") as fh:
     long_description = fh.read()
 
 dependencies = [
-    # "chia-blockchain @ git+https://github.com/Chia-Network/chia-blockchain.git@1.6.2",
-    "chia-blockchain==1.6.2",
     "packaging==21.3",
+    "anyio",
+]
+
+release_dependencies = [
+    "chia-blockchain==1.6.2",
+    "chia-dev-tools~=1.1.4",
 ]
 
 dev_dependencies = [
     "build",
+    "chia-blockchain @ git+https://github.com/Chia-Network/chia-blockchain.git@main",
+    "chia-dev-tools @ git+https://github.com/Chia-Network/chia-dev-tools.git@wallentx/target-main",  # Will change to '@main' if changes get merged to chia-dev-tools
     "click~=8.1.3",
-    "chia-dev-tools~=1.1.4",
     "coverage",
     "pre-commit",
     "pylint",
@@ -69,6 +74,7 @@ setup(
         "Topic :: Security :: Cryptography",
     ],
     extras_require=dict(
+        release=release_dependencies,
         dev=dev_dependencies,
     ),
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "rt", encoding="UTF-8") as fh:
     long_description = fh.read()
 
 dependencies = [
-    "packaging~=23.0",
+    "packaging",
     "anyio",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ with open("README.md", "rt", encoding="UTF-8") as fh:
     long_description = fh.read()
 
 dependencies = [
-    "packaging==21.3",
+    "packaging~=23.0",
     "anyio",
 ]
 
 release_dependencies = [
-    "chia-blockchain==1.6.2",
+    "chia-blockchain~=1.7.0",
     "chia-dev-tools~=1.1.4",
 ]
 


### PR DESCRIPTION
This includes changes that introduces the following concepts that provide a separation of concerns:

> Install using latest chia-blockchain release: pip install .[release]

> Install using main branch of chia-blockchain: pip install .[dev]

This may not be fully compliant with what is allowed for publishing, as I'm simply fumbling around attempting to express a goal- which is to have a way to test this tool against the current state of chia-blockchain, as well as the latest release.

This branch is currently targets `wallentx/target-main` on https://github.com/Chia-Network/chia-dev-tools, which is being configured in a similar fashion to provide the same goal, and https://github.com/Chia-Network/chia-dev-tools/pull/70 would need to be merged (and the target on this branch redirected to `main`) prior to merging this.