### PR TITLE
Update run-tests.yml for fixes in nightly

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,19 +32,14 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
-
-      - name: Setup simulator
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Test code with pytest
         shell: bash


### PR DESCRIPTION
Reflect the changes requested by @cmmarslender in https://github.com/Chia-Network/chia-nft-minting-tool/pull/58

Remove the duplicate set up python
Move to python 3.10
use checkout at v4