### PR TITLE
Match version to GH tag, add 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,12 @@ dev_dependencies = [
     "mypy==1.12.0",
     "black==24.10.0",
     "types-setuptools==75.1.0.20241014",
-    "pre-commit==3.5.0; python_version < '3.9'",
-    "pre-commit==4.0.1; python_version >= '3.9'",
+    "pre-commit==4.0.1",
 ]
 
 setup(
     name="chianft",
-    version="0.1",
+    version="0.0.6",
     packages=find_packages(exclude=("tests",)),
     author="Geoff Walmsley",
     entry_points={
@@ -47,6 +46,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Security :: Cryptography",
     ],


### PR DESCRIPTION
Match the version in setup.py to the GH tag
Add python 3.12 identifier
Cleanup some stuff in setup related to python 3.8 which is no longer supported